### PR TITLE
First version o kafka's integration test

### DIFF
--- a/spec/services/kafka_spec.rb
+++ b/spec/services/kafka_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+service = 'kafka'
+port = 9092
+service_status = command("systemctl is-enabled #{service}").stdout.strip
+
+packages = %w[redborder-kafka librdkafka n2kafka rsyslog-kafka]
+
+describe "Checking packages for #{service}..." do
+  packages.each do |package|
+    describe package(package) do
+      before do
+        skip("#{package} is not installed, skipping...") unless package(package).installed?
+      end
+
+      it 'is expected to be installed' do
+        expect(package(package).installed?).to be true
+      end
+    end
+  end
+end
+
+if service_status == 'enabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe port(port) do
+      it { should be_listening }
+    end
+  end
+end
+
+if service_status == 'disabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+
+    describe port(port) do
+      it { should_not be_listening }
+    end
+  end
+end


### PR DESCRIPTION
### Kafka Service Verification Tests

This PR introduces a comprehensive suite of Serverspec tests for Kafka. It validates the installation of critical Kafka-related packages (`redborder-kafka`, `librdkafka`, `n2kafka`, `rsyslog-kafka`) and ensures the Kafka service and port configurations are correctly set up. 

The tests dynamically adapt based on the Kafka service's status, checking if the service is properly enabled or disabled. 

This ensures our Kafka setup is robust, reliable, and adheres to expected configurations.
