### PR TITLE
Added Serverspec tests for f2k service, covering package, service sta…

### DIFF
--- a/spec/services/f2k_spec.rb
+++ b/spec/services/f2k_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'json'
 set :os, family: 'redhat', release: '9', arch: 'x86_64'
 
 service = 'f2k'

--- a/spec/services/f2k_spec.rb
+++ b/spec/services/f2k_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+service = 'f2k'
+port = 2055
+service_status = command("systemctl is-enabled #{service}").stdout.strip
+
+packages = %w[f2k]
+
+describe "Checking packages for #{service}..." do
+  packages.each do |package|
+    describe package(package) do
+      before do
+        skip("#{package} is not installed, skipping...") unless package(package).installed?
+      end
+
+      it 'is expected to be installed' do
+        expect(package(package).installed?).to be true
+      end
+    end
+  end
+end
+
+if service_status == 'enabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe port(port) do
+      it { should be_listening }
+    end
+  end
+end
+
+if service_status == 'disabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+
+    describe port(port) do
+      it { should_not be_listening }
+    end
+  end
+end


### PR DESCRIPTION
### Enhanced Serverspec Testing for `f2k`

This MR introduces an extended suite of Serverspec tests focused on the `f2k` service. It ensures:

- The `f2k` package is properly installed.
- The service is correctly enabled or disabled based on the system configuration.
- The service is actively listening on the designated port (2055).

