### PR TITLE
Added Serverspec tests for SNMP (net-snmp) covering package, service status, and port 199 listening

### DIFF
--- a/spec/services/snmpd_spec.rb
+++ b/spec/services/snmpd_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+packages = %w[
+  net-snmp
+]
+
+service = 'snmpd'
+port = 199
+
+describe "Checking packages for #{service}..." do
+  packages.each do |package|
+    describe package(package) do
+      before do
+        skip("#{package} is not installed, skipping...") unless package(package).installed?
+      end
+
+      it 'is expected to be installed' do
+        expect(package(package).installed?).to be true
+      end
+    end
+  end
+end
+
+service_status = command("systemctl is-enabled #{service}").stdout
+service_status = service_status.strip
+
+if service_status == 'enabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe port(port) do
+      it { should be_listening }
+    end
+  end
+end
+
+if service_status == 'disabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+
+    describe port(port) do
+      it { should_not be_listening }
+    end
+  end
+end


### PR DESCRIPTION
### SNMP Testing with Serverspec

This MR introduces a set of Serverspec tests for the SNMP service (`snmpd`) on Red Hat OS:

- Validates the installation of the `net-snmp` package.
- Checks whether the `snmpd` service is correctly enabled/disabled as per configuration.
- Ensures the service is actively listening on port 199.

These tests are vital for confirming the operational health and configuration compliance of the SNMP service in our infrastructure.
